### PR TITLE
Pentest tweaks

### DIFF
--- a/radar_patient_check/database.py
+++ b/radar_patient_check/database.py
@@ -1,4 +1,5 @@
-from sqlmodel import create_engine, Session
+from sqlmodel import Session, create_engine
+
 from .config import settings
 
 

--- a/radar_patient_check/demo.py
+++ b/radar_patient_check/demo.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass
 import datetime
+from dataclasses import dataclass
 
 
 @dataclass

--- a/radar_patient_check/main.py
+++ b/radar_patient_check/main.py
@@ -25,7 +25,7 @@ class RadarCheckRequest(BaseModel):
 class RadarCheckResponse(BaseModel):
     nhs_number: bool = Field(
         ...,
-        description="NHS number matched against a known RADAR enrecord",
+        description="NHS number matched against a known RADAR record",
         alias="nhsNumber",
     )
     date_of_birth: bool = Field(

--- a/radar_patient_check/main.py
+++ b/radar_patient_check/main.py
@@ -1,16 +1,14 @@
 from datetime import date
-from pydantic import BaseModel, Field
+from typing import Optional
 
-from fastapi import Depends, FastAPI, HTTPException
-from fastapi.security import OAuth2PasswordBearer
+from fastapi import Depends, FastAPI, HTTPException, Security
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import BaseModel, Field
 from ukrdc_sqla.ukrdc import Patient, PatientNumber, ProgramMembership
 
-from radar_patient_check.demo import DEMO_PATIENTS_MAP
-
-from .database import get_session
 from .config import settings
-
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+from .database import get_session
+from .demo import DEMO_PATIENTS_MAP
 
 app = FastAPI()
 
@@ -27,7 +25,7 @@ class RadarCheckRequest(BaseModel):
 class RadarCheckResponse(BaseModel):
     nhs_number: bool = Field(
         ...,
-        description="NHS number matched against a known RADAR record",
+        description="NHS number matched against a known RADAR enrecord",
         alias="nhsNumber",
     )
     date_of_birth: bool = Field(
@@ -40,15 +38,24 @@ class RadarCheckResponse(BaseModel):
         allow_population_by_field_name = True
 
 
-def api_key_auth(request_key: str = Depends(oauth2_scheme)):
+def api_key_auth(
+    token: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer()),
+):
+    # Handle missing auth header
+    if not token:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    # Extract API key from auth header
+    request_key = token.credentials
+    # Load allowed API keys
     api_keys = settings.apikeys
+    # Check API key in auth header
     if not api_keys or (api_keys and request_key not in api_keys):
         raise HTTPException(status_code=401, detail="Forbidden")
 
 
 @app.post(
     "/radar_check/",
-    dependencies=[Depends(api_key_auth)],
+    dependencies=[Security(api_key_auth)],
     response_model=RadarCheckResponse,
 )
 async def radar_check(

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,11 +1,12 @@
 import pytest
 from fastapi.testclient import TestClient
-from radar_patient_check.config import settings
-from radar_patient_check.database import get_session
-from radar_patient_check.main import app
 from sqlmodel import Session, create_engine
 from sqlmodel.pool import StaticPool
 from ukrdc_sqla.ukrdc import Base as UKRDC3Base
+
+from radar_patient_check.config import settings
+from radar_patient_check.database import get_session
+from radar_patient_check.main import app
 
 
 @pytest.fixture(name="session")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,13 +2,14 @@ import datetime
 
 import pytest
 from fastapi.testclient import TestClient
-from radar_patient_check.config import settings
-from radar_patient_check.database import get_session
-from radar_patient_check.main import app
 from sqlmodel import Session, create_engine
 from sqlmodel.pool import StaticPool
 from ukrdc_sqla.ukrdc import Base as UKRDC3Base
 from ukrdc_sqla.ukrdc import Patient, PatientNumber, ProgramMembership
+
+from radar_patient_check.config import settings
+from radar_patient_check.database import get_session
+from radar_patient_check.main import app
 
 
 def _create_test_data(session: Session):


### PR DESCRIPTION
The intention here was originally to address the pentest result pointing out that the server JSON-validates the request body _before_ checking the API key. 

Note:

1. This only affects cases where the request body is invalid JSON. Actual input schema validation happens _after_ security checks.
2. This is common behaviour in FastAPI. Every example I've found behaves the same.
3. It's unclear if it's even possible to change this behaviour.

Nevertheless, I've made a couple of tweaks here worth having:

* Sorted imports (this was kind of an accident as a result of a VSCode extension, but no harm I suppose).
* Switched to the correct `HTTPBearer` security class instead of the OAuth2 class being used
  * This doesn't practically change anything in-use, but it means the auto-generated API docs and Swagger client now show the correct interface for entering an auth token.