### PR TITLE
feat: add route to check general ukrdc presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@
     <img src="images/UKKA Kidney Blue.png" alt="Logo" width="80" height="80">
   </a>
 
-<h3 align="center">Radar Patient Check</h3>
+<h3 align="center">"Radar" (UKRDC) Patient Check</h3>
 
   <p align="center">
-    An API for checking that a patient identifier is present in <a href="https://ukkidney.org/rare-renal/homepage"><strong>Radar</strong></a>
+    An API for checking if a patient is present in the UKRDC.
     <br />
     <a href="https://github.com/renalreg/radar-patient-check/issues">Report Bug</a>
     ·
@@ -30,7 +30,7 @@
 
 ## About The Project
 
-This API was created to allow other applications to verify if a patient is present in <a href="https://ukkidney.org/rare-renal/homepage"><strong>Radar</strong></a> using memberships found in the <a href="https://ukkidney.org/audit-research/data-permissions/ukrdc"><strong>UKRDC</strong></a> database.
+This API was originally created to allow other applications to verify if a patient is present in <a href="https://ukkidney.org/rare-renal/homepage"><strong>RADAR</strong></a> using memberships found in the <a href="https://ukkidney.org/audit-research/data-permissions/ukrdc"><strong>UKRDC</strong></a> database. It has now expanded in scope to cover checking a patient's general presence in the UKRDC.
 
 ### Built With
 
@@ -77,7 +77,8 @@ To get a local copy up and running follow these simple example steps.
 
    ```python
    SQLALCHEMY_DATABASE_URL = ""
-   APIKEYS = ["", ""]
+   RADAR_APIKEYS = ["", ""]
+   UKRDC_APIKEYS = ["", ""]
    ```
 
 6. Start the server. Only use reload for development
@@ -108,7 +109,8 @@ To deploy for production follow the following steps.
 
    ```python
    SQLALCHEMY_DATABASE_URL = ""
-   APIKEYS = ["", ""]
+   RADAR_APIKEYS = ["", ""]
+   UKRDC_APIKEYS = ["", ""]
    ```
 
 3. Start the docker container
@@ -133,15 +135,27 @@ The headers need to include and authorization key value pair.
 "Authorization" : "Bearer XXXXXXXXXXXXX"
 ```
 
-## Request Body
+## API routes
 
-Requests should be sent using the URL
+### RADAR Membership
 
 ```
 POST: /radar_check/
 ```
 
-with a body containing the following
+Checks if a patient is present in the UKRDC, and has a `RADAR.COHORT.INS` program membership.
+
+### UKRDC Presence
+
+```
+POST: /ukrdc_check/
+```
+
+Checks if a patient is present in the UKRDC.
+
+## Request Body
+
+Requests should be sent with a body containing the following
 
 ```json
 {
@@ -163,9 +177,9 @@ The API will then respond in the following format
 }
 ```
 
-Where `nhsNumber` is a boolean value indicating if the NHS number is present and has an active RADAR membership, and `dateOfBirth` is a boolean value indicating if the date of birth matches.
+Where `nhsNumber` is a boolean value indicating if the NHS number is present and matches the required conditions (e.g. RADAR membership), and `dateOfBirth` is a boolean value indicating if the date of birth matches.
 
-Note, if the NHS number does not have a RADAR membership, the `dateOfBirth` response will always be `false`.
+Note, if the NHS number does not match the required conditions (e.g. UKRDC presence or RADAR membership), the `dateOfBirth` response will always be `false`.
 
 <br />
 

--- a/radar_patient_check/config.py
+++ b/radar_patient_check/config.py
@@ -5,7 +5,9 @@ from pydantic import BaseSettings
 
 class Settings(BaseSettings):
     sqlalchemy_database_url: Optional[str] = None
-    apikeys: List[str] = []
+
+    radar_apikeys: List[str] = []
+    ukrdc_apikeys: List[str] = []
 
     class Config:
         env_file = ".env"

--- a/radar_patient_check/main.py
+++ b/radar_patient_check/main.py
@@ -13,7 +13,7 @@ from .demo import DEMO_PATIENTS_MAP
 app = FastAPI()
 
 
-class RadarCheckRequest(BaseModel):
+class RecordCheckRequest(BaseModel):
     nhs_number: str = Field(
         ..., description="The patient's NHS number", alias="nhsNumber"
     )
@@ -22,7 +22,7 @@ class RadarCheckRequest(BaseModel):
     )
 
 
-class RadarCheckResponse(BaseModel):
+class RecordCheckResponse(BaseModel):
     nhs_number: bool = Field(
         ...,
         description="NHS number matched against a known RADAR record",
@@ -38,29 +38,50 @@ class RadarCheckResponse(BaseModel):
         allow_population_by_field_name = True
 
 
-def api_key_auth(
-    token: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer()),
+def base_api_key_auth(
+    key_list: list[str],
+    token: Optional[HTTPAuthorizationCredentials],
 ):
+    """Base FastAPI dependency for API key authentication
+
+    Args:
+        key_list (list[str]): List of valid API keys
+        token (Optional[HTTPAuthorizationCredentials], optional): FastAPI HTTPBearer token. Defaults to Depends(HTTPBearer()).
+    """
     # Handle missing auth header
     if not token:
         raise HTTPException(status_code=401, detail="Unauthorized")
     # Extract API key from auth header
     request_key = token.credentials
-    # Load allowed API keys
-    api_keys = settings.apikeys
     # Check API key in auth header
-    if not api_keys or (api_keys and request_key not in api_keys):
+    if request_key not in key_list:
         raise HTTPException(status_code=401, detail="Forbidden")
 
+def radar_api_key_auth(
+    token: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer()),
+):
+    """
+    FastAPI dependency for RADAR API key authentication
+    """
+    base_api_key_auth(settings.radar_apikeys, token)
+
+def ukrdc_api_key_auth(
+    token: Optional[HTTPAuthorizationCredentials] = Depends(HTTPBearer()),
+):
+    """
+    FastAPI dependency for UKRDC API key authentication
+    """
+    base_api_key_auth(settings.ukrdc_apikeys, token)
+    
 
 @app.post(
     "/radar_check/",
-    dependencies=[Security(api_key_auth)],
-    response_model=RadarCheckResponse,
+    dependencies=[Security(radar_api_key_auth)],
+    response_model=RecordCheckResponse,
 )
 async def radar_check(
-    record: RadarCheckRequest, session=Depends(get_session)
-) -> RadarCheckResponse:
+    record: RecordCheckRequest, session=Depends(get_session)
+) -> RecordCheckResponse:
     """
     Checks to see if an NHS number is linked to a Radar membership,
     and if the DoB provided matches that on file.
@@ -70,9 +91,9 @@ async def radar_check(
 
     # NOTE: Pylance (VS Code language server) struggles with this line as Pydantic aliases confuse it.
     #       It's fine to ignore the error.
-    response = RadarCheckResponse(nhs_number=False, date_of_birth=False)  # type: ignore
+    response = RecordCheckResponse(nhs_number=False, date_of_birth=False)  # type: ignore
 
-    # Handle NHS demo patients
+    # Handle NHS demo patients for INS app
     if record.nhs_number in DEMO_PATIENTS_MAP:
         demo_patient = DEMO_PATIENTS_MAP[record.nhs_number]
         if demo_patient.is_radar_member:
@@ -92,20 +113,59 @@ async def radar_check(
             .filter(
                 ProgramMembership.pid.in_(pids),
                 ProgramMembership.program_name == "RADAR.COHORT.INS",
-                ProgramMembership.to_time == None,
+                ProgramMembership.to_time == None,  # noqa: E711
             )
             .first()
         ):
             response.nhs_number = True
 
-            recorded_dobs = (
+            recorded_dobs_query = (
                 session.query(Patient.birth_time).filter(Patient.pid.in_(pids)).all()
             )
 
             recorded_dobs = [
-                recorded_dob.birth_time.date() for recorded_dob in recorded_dobs
+                recorded_dob.birth_time.date() for recorded_dob in recorded_dobs_query
             ]
 
             response.date_of_birth = record.date_of_birth in recorded_dobs
+
+    return response
+
+
+@app.post(
+    "/ukrdc_check/",
+    dependencies=[Security(ukrdc_api_key_auth)],
+    response_model=RecordCheckResponse,
+)
+async def ukrdc_check(
+    record: RecordCheckRequest, session=Depends(get_session)
+) -> RecordCheckResponse:
+    """
+    Checks to see if an NHS number is linked to a UKRDC record,
+    and if the DoB provided matches that on file.
+
+    Can return true for the NHS number and false for the DoB if the membership exists but DoB does not match.
+    """
+
+    response = RecordCheckResponse(nhs_number=False, date_of_birth=False)  # type: ignore
+
+    if (
+        patient_numbers := session.query(PatientNumber)
+        .filter_by(patientid=record.nhs_number, numbertype="NI")
+        .all()
+    ):
+        pids = [patient_number.pid for patient_number in patient_numbers]
+
+        response.nhs_number = True
+
+        recorded_dobs_query = (
+            session.query(Patient.birth_time).filter(Patient.pid.in_(pids)).all()
+        )
+
+        recorded_dobs = [
+            recorded_dob.birth_time.date() for recorded_dob in recorded_dobs_query
+        ]
+
+        response.date_of_birth = record.date_of_birth in recorded_dobs
 
     return response

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,91 @@
+import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlmodel import Session, create_engine
+from sqlmodel.pool import StaticPool
+from ukrdc_sqla.ukrdc import Base as UKRDC3Base
+from ukrdc_sqla.ukrdc import Patient, PatientNumber, ProgramMembership
+
+from radar_patient_check.config import settings
+from radar_patient_check.database import get_session
+from radar_patient_check.main import app
+
+
+def _create_test_data(session: Session):
+    # Test patient with RADAR membership
+    session.add(
+        Patient(
+            pid=1,
+            birth_time=datetime.datetime(2000, 1, 1),
+        )
+    )
+
+    session.add(
+        PatientNumber(
+            id=1, pid=1, patientid="8888888888", numbertype="NI", organization="NHS"
+        )
+    )
+
+    session.add(
+        ProgramMembership(
+            id=1,
+            pid=1,
+            program_name="RADAR.COHORT.INS",
+            to_time=None,
+        )
+    )
+
+    # Test patient without RADAR membership
+
+    session.add(
+        Patient(
+            pid=2,
+            birth_time=datetime.datetime(2001, 1, 1),
+        )
+    )
+
+    session.add(
+        PatientNumber(
+            id=2, pid=2, patientid="9999999999", numbertype="NI", organization="NHS"
+        )
+    )
+    session.commit()
+
+
+@pytest.fixture(name="session")
+def session_fixture():
+    """
+    Create an in-memory test database and return a session.
+    """
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    UKRDC3Base.metadata.tables["patient"].create(bind=engine)
+    UKRDC3Base.metadata.tables["patientnumber"].create(bind=engine)
+    UKRDC3Base.metadata.tables["programmembership"].create(bind=engine)
+
+    with Session(engine) as session:
+        _create_test_data(session)
+        yield session
+
+
+@pytest.fixture(name="client")
+def client_fixture(session: Session):
+    """
+    Create a test client and override the FastAPI dependency.
+    Depends on the session fixture.
+    """
+    settings.radar_apikeys = ["PYTESTKEY0000000000"]
+    settings.ukrdc_apikeys = ["PYTESTKEY0000000001"]
+
+    def get_session_override():
+        return session
+
+    app.dependency_overrides[get_session] = get_session_override
+
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,49 +1,4 @@
-import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session, create_engine
-from sqlmodel.pool import StaticPool
-from ukrdc_sqla.ukrdc import Base as UKRDC3Base
-
-from radar_patient_check.config import settings
-from radar_patient_check.database import get_session
-from radar_patient_check.main import app
-
-
-@pytest.fixture(name="session")
-def session_fixture():
-    """
-    Create an in-memory test database and return a session.
-    """
-    engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    UKRDC3Base.metadata.tables["patient"].create(bind=engine)
-    UKRDC3Base.metadata.tables["patientnumber"].create(bind=engine)
-    UKRDC3Base.metadata.tables["programmembership"].create(bind=engine)
-
-    with Session(engine) as session:
-        yield session
-
-
-@pytest.fixture(name="client")
-def client_fixture(session: Session):
-    """
-    Create a test client and override the FastAPI dependency.
-    Depends on the session fixture.
-    """
-    settings.apikeys = ["PYTESTKEY0000000000"]
-
-    def get_session_override():
-        return session
-
-    app.dependency_overrides[get_session] = get_session_override
-
-    client = TestClient(app)
-    yield client
-    app.dependency_overrides.clear()
-
 
 def test_main_radar_check(client: TestClient):
     response = client.post(

--- a/tests/test_main_radar.py
+++ b/tests/test_main_radar.py
@@ -1,94 +1,4 @@
-import datetime
-
-import pytest
 from fastapi.testclient import TestClient
-from sqlmodel import Session, create_engine
-from sqlmodel.pool import StaticPool
-from ukrdc_sqla.ukrdc import Base as UKRDC3Base
-from ukrdc_sqla.ukrdc import Patient, PatientNumber, ProgramMembership
-
-from radar_patient_check.config import settings
-from radar_patient_check.database import get_session
-from radar_patient_check.main import app
-
-
-def _create_test_data(session: Session):
-    # Test patient with RADAR membership
-    session.add(
-        Patient(
-            pid=1,
-            birth_time=datetime.datetime(2000, 1, 1),
-        )
-    )
-
-    session.add(
-        PatientNumber(
-            id=1, pid=1, patientid="8888888888", numbertype="NI", organization="NHS"
-        )
-    )
-
-    session.add(
-        ProgramMembership(
-            id=1,
-            pid=1,
-            program_name="RADAR",
-            to_time=None,
-        )
-    )
-
-    # Test patient without RADAR membership
-
-    session.add(
-        Patient(
-            pid=2,
-            birth_time=datetime.datetime(2001, 1, 1),
-        )
-    )
-
-    session.add(
-        PatientNumber(
-            id=2, pid=2, patientid="9999999999", numbertype="NI", organization="NHS"
-        )
-    )
-    session.commit()
-
-
-@pytest.fixture(name="session")
-def session_fixture():
-    """
-    Create an in-memory test database and return a session.
-    """
-    engine = create_engine(
-        "sqlite://",
-        connect_args={"check_same_thread": False},
-        poolclass=StaticPool,
-    )
-    UKRDC3Base.metadata.tables["patient"].create(bind=engine)
-    UKRDC3Base.metadata.tables["patientnumber"].create(bind=engine)
-    UKRDC3Base.metadata.tables["programmembership"].create(bind=engine)
-
-    with Session(engine) as session:
-        _create_test_data(session)
-        yield session
-
-
-@pytest.fixture(name="client")
-def client_fixture(session: Session):
-    """
-    Create a test client and override the FastAPI dependency.
-    Depends on the session fixture.
-    """
-    settings.apikeys = ["PYTESTKEY0000000000"]
-
-    def get_session_override():
-        return session
-
-    app.dependency_overrides[get_session] = get_session_override
-
-    client = TestClient(app)
-    yield client
-    app.dependency_overrides.clear()
-
 
 def test_main_radar_check(client: TestClient):
     response = client.post(
@@ -165,13 +75,13 @@ def test_main_radar_check_no_token(client: TestClient):
             "dateOfBirth": "2000-01-01",
         },
     )
-    assert response.status_code == 401
+    assert response.status_code == 403
 
 
 def test_main_radar_check_bad_token(client: TestClient):
     response = client.post(
         "/radar_check/",
-        headers={"Authorization": "Bearer BADTOKEN"},
+        headers={"Authorization": "Bearer PYTESTKEY0000000001"},
         json={
             "nhsNumber": "8888888888",
             "dateOfBirth": "2000-01-01",

--- a/tests/test_main_ukrdc.py
+++ b/tests/test_main_ukrdc.py
@@ -1,0 +1,73 @@
+from fastapi.testclient import TestClient
+
+def test_main_ukrdc_check(client: TestClient):
+    response = client.post(
+        "/ukrdc_check/",
+        headers={"Authorization": "Bearer PYTESTKEY0000000001"},
+        json={
+            "nhsNumber": "9999999999",
+            "dateOfBirth": "2001-01-01",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"nhsNumber": True, "dateOfBirth": True}
+
+
+def test_main_ukrdc_check_no_patient(client: TestClient):
+    response = client.post(
+        "/ukrdc_check/",
+        headers={"Authorization": "Bearer PYTESTKEY0000000001"},
+        json={
+            "nhsNumber": "6",
+            "dateOfBirth": "1900-01-01",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"nhsNumber": False, "dateOfBirth": False}
+
+
+def test_main_ukrdc_check_nhs_correct_dob_not(client: TestClient):
+    response = client.post(
+        "/ukrdc_check/",
+        headers={"Authorization": "Bearer PYTESTKEY0000000001"},
+        json={
+            "nhsNumber": "9999999999",
+            "dateOfBirth": "1900-01-01",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"nhsNumber": True, "dateOfBirth": False}
+
+
+def test_main_ukrdc_check_nhs_correct_dob_missing(client: TestClient):
+    response = client.post(
+        "/ukrdc_check/",
+        headers={"Authorization": "Bearer PYTESTKEY0000000001"},
+        json={
+            "nhsNumber": "9999999999",
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_main_ukrdc_check_no_token(client: TestClient):
+    response = client.post(
+        "/ukrdc_check/",
+        json={
+            "nhsNumber": "9999999999",
+            "dateOfBirth": "2001-01-01",
+        },
+    )
+    assert response.status_code == 403
+
+
+def test_main_ukrdc_check_bad_token(client: TestClient):
+    response = client.post(
+        "/ukrdc_check/",
+        headers={"Authorization": "Bearer PYTESTKEY0000000000"},
+        json={
+            "nhsNumber": "9999999999",
+            "dateOfBirth": "2001-01-01",
+        },
+    )
+    assert response.status_code == 401


### PR DESCRIPTION
Adds a new API route to check if a patient is in the UKRDC at all. This change also splits API keys into a set for checking RADAR memberships, and a set for checking general UKRDC presence.

@andyatterton might be worth you just glancing over this given I think you wrote the original code?